### PR TITLE
Add ssh_gateway as an option to for SSH Transport

### DIFF
--- a/lib/chef_metal_fog/fog_provisioner.rb
+++ b/lib/chef_metal_fog/fog_provisioner.rb
@@ -535,6 +535,7 @@ module ChefMetalFog
 
       #Enable pty by default
       options[:ssh_pty_enable] = true
+      options[:ssh_gateway] = compute_options[:ssh_gateway] if compute_options.key?(:ssh_gateway)
 
       ChefMetal::Transport::SSH.new(remote_host, username, ssh_options, options)
     end


### PR DESCRIPTION
This change provides the ssh_gateway attribute which is passed as an option to the Transport object. A further pull request on chef-metal then allows Transport to use an intermediate Net::SSH::Gateway object to pass through the gateway node. 

ssh_gateway is assumed to be in the same syntax as that found on knife-ec2. 
