### PR TITLE
Instances spin up with "default" name

### DIFF
--- a/lib/chef_metal_fog/fog_provisioner.rb
+++ b/lib/chef_metal_fog/fog_provisioner.rb
@@ -205,7 +205,7 @@ module ChefMetalFog
       if need_to_create
         # If the server does not exist, create it
         bootstrap_options = bootstrap_options_for(action_handler.new_resource, node)
-        bootstrap_options = bootstrap_options.merge(:name => action_handler.new_resource.name)
+        bootstrap_options = bootstrap_options.merge(:name => node['name'])
 
         start_time = Time.now
         timeout = option_for(node, :create_timeout)


### PR DESCRIPTION
When spinning up instances, they are all created with the name "default" (at least in Openstack, if that's not the case elsewhere then we have a different issue).  

It appears the issue is related to:

https://github.com/opscode/chef-metal-fog/blob/master/lib/chef_metal_fog/fog_provisioner.rb#L208

It looks like it's pulling the name from `machine_batch[default]` rather than the actual `node['name']`.

If this was intentional, then I'll need to keep digging!  Thanks!
