### PR TITLE
Create new transport to avoid execution expired errors

### DIFF
--- a/lib/chef_metal_fog/fog_driver.rb
+++ b/lib/chef_metal_fog/fog_driver.rb
@@ -306,6 +306,7 @@ module ChefMetalFog
     end
 
     def wait_for_transport(action_handler, machine_spec, machine_options, server)
+      driver = self
       transport = transport_for(machine_spec, server)
       if !transport.available?
         if action_handler.should_perform_actions
@@ -314,6 +315,7 @@ module ChefMetalFog
           _self = self
 
           server.wait_for(remaining_wait_time(machine_spec, machine_options)) do
+            transport = driver.transport_for(machine_spec, server)
             transport.available?
           end
           action_handler.report_progress "#{machine_spec.name} is now connectable"


### PR DESCRIPTION
I got execution expired ssh errors when reusing the same transport. Creating a new transport fixed the problem.
