### PR TITLE
only compare the relevant bits of the ssh key fingerprint

### DIFF
--- a/lib/chef/provider/fog_key_pair.rb
+++ b/lib/chef/provider/fog_key_pair.rb
@@ -75,7 +75,7 @@ class Chef::Provider::FogKeyPair < Chef::Provider::LWRPBase
         end
       end
 
-      if !new_fingerprints.any? { |f| f == @current_fingerprint }
+      if !new_fingerprints.any? { |f| compare_public_key f }
         if new_resource.allow_overwrite
           converge_by "update #{key_description} to match local key at #{new_resource.private_key_path}" do
             case new_driver.compute_options[:provider]
@@ -153,6 +153,12 @@ class Chef::Provider::FogKeyPair < Chef::Provider::LWRPBase
 
   def current_resource_exists?
     @current_resource.action != [ :delete ]
+  end
+
+  def compare_public_key(new)
+    c = @current_fingerprint.split[0,2].join(' ')
+    n = new.split[0,2].join(' ')
+    c == n
   end
 
   def compute


### PR DESCRIPTION
When comparing fingerprints, the last section is host specific - but
it's irrelevant. So we chop that bit off, and ensure that the actual
algorithm and public key still match.
