### PR TITLE
Return an empty string for CloudStack #creator

### DIFF
--- a/lib/chef_metal_fog/providers/cloudstack.rb
+++ b/lib/chef_metal_fog/providers/cloudstack.rb
@@ -4,6 +4,10 @@ module ChefMetalFog
 
       ChefMetalFog::FogDriver.register_provider_class('CloudStack', ChefMetalFog::Providers::CloudStack)
 
+      def creator
+        ''
+      end
+
       def self.compute_options_for(provider, id, config)
         new_compute_options = {}
         new_compute_options[:provider] = provider


### PR DESCRIPTION
Commit 1c260fb93d made #creator raise if it isn't implemented by a provider. The CloudStack provider provider does not have #creator implemented which causes it to fail.

This PR implements #creator and makes it return an empty string for CloudStack.
