### PR TITLE
[openstack] fix floating ip attaching

### DIFF
--- a/lib/chef_metal_fog/providers/openstack.rb
+++ b/lib/chef_metal_fog/providers/openstack.rb
@@ -32,6 +32,45 @@ module ChefMetalFog
         [result, id]
       end
 
+      # Check given IP already attached and attach if necessary
+      def attach_floating_ips(action_handler, machine_spec, machine_options, server)
+        if option_for(machine_options, :floating_ip_pool)
+          Chef::Log.info 'Attaching IP from pool'
+          action_handler.perform_action "attach floating IP from #{option_for(machine_options, :floating_ip_pool)} pool" do
+            pool = option_for(machine_options, :floating_ip_pool)
+            allocated_addresses = server.addresses[pool]
+            if ! allocated_addresses.nil?
+              allocated_addresses.select {|a_info| a_info['OS-EXT-IPS:type']=='floating'}
+              if allocated_addresses.length>0
+                Chef::Log.info "Address from pool <#{pool}> already allocated"
+                return true
+              end
+            end
+            attach_ip_from_pool(server, pool)
+          end
+        elsif option_for(machine_options, :floating_ip)
+          Chef::Log.info 'Attaching given IP'
+          action_handler.perform_action "attach floating IP #{option_for(machine_options, :floating_ip)}" do
+            ip = option_for(machine_options, :floating_ip)
+            allocated_addresses = []
+            server.addresses.keys.each do |pool|
+              server.addresses[pool].each {|a_info| allocated_addresses<<a_info['addr']}
+            end
+            if allocated_addresses.include? ip
+              Chef::Log.info "Address <#{ip}> already allocated"
+            else
+              attach_ip(server, ip)
+            end
+          end
+        end
+      end
+
+      # Attach given IP to machine
+      def attach_ip(server, ip)
+        Chef::Log.info "Attaching floating IP <#{ip}>"
+        compute.associate_address(server.id, ip)
+      end
+
     end
   end
 end


### PR DESCRIPTION
- Check that floating IP already attached;
- Fix floating IP attaching.

I really don't know how it work previously, cause in fog_driver.rb attach_ip() executes in different ways from attach_*() functions.