### PR TITLE
Fix `machine_options[:convergence_options]` to always have a hash value and not be nil

### DIFF
--- a/lib/chef_metal_fog/providers/aws.rb
+++ b/lib/chef_metal_fog/providers/aws.rb
@@ -116,6 +116,7 @@ module ChefMetalFog
       end
 
       def convergence_strategy_for(machine_spec, machine_options)
+        machine_options[:convergence_options] ||= {}
         machine_options[:convergence_options][:ohai_hints] = { 'ec2' => ''}
         super(machine_spec, machine_options)
       end


### PR DESCRIPTION
The provider/aws.rb `AWS#convergence_strategy_for` method expected its argument `machine_options` to have a key :convergence_options that had a
hash as its value. But there seems to be conditions that would not
initialize that hash so it would be nil. The method tries to:
`machine_options[:convergence_options][:ohai_hints] = { 'ec2' => ''}`
which fails without this fix.

The fix just initializes `machine_options[:convergence_options]` to an
empty hash if its nil.
