### PR TITLE
Adds a machine_options param to the private_key_for method.

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -572,9 +572,10 @@ module FogDriver
     # Get the private key for a machine - prioritize the server data, fall back to the
     # the machine spec data, and if that doesn't work, raise an exception.
     # @param [Hash] machine_spec Machine spec data
+    # @param [Hash] machine_options Machine options
     # @param [Chef::Provisioning::Machine] server a Machine representing the server
     # @return [String] PEM-encoded private key
-    def private_key_for(machine_spec, server)
+    def private_key_for(machine_spec, machine_options, server)
       if server.respond_to?(:private_key) && server.private_key
          server.private_key
       elsif server.respond_to?(:key_name) && server.key_name
@@ -605,7 +606,7 @@ module FogDriver
         :keys_only => true,
         :host_key_alias => "#{server.id}.#{provider}"
       }.merge(machine_options[:ssh_options] || {})
-      result[:key_data] = [ private_key_for(machine_spec, server) ]
+      result[:key_data] = [ private_key_for(machine_spec, machine_options, server) ]
       result
     end
 

--- a/lib/chef/provisioning/fog_driver/providers/aws.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws.rb
@@ -47,7 +47,7 @@ module FogDriver
         port = machine_spec.location['winrm_port'] || 5985
         endpoint = "http://#{remote_host}:#{port}/wsman"
         type = :plaintext
-        pem_bytes = private_key_for(machine_spec, server)
+        pem_bytes = private_key_for(machine_spec, machine_options, server)
         encrypted_admin_password = wait_for_admin_password(machine_spec)
         decoded = Base64.decode64(encrypted_admin_password)
         private_key = OpenSSL::PKey::RSA.new(pem_bytes)


### PR DESCRIPTION
The Chef::Provisioning::FogDriver::private_key_for tries to access an
undefined variable or method `machine_options`. This commit adds that as
a param to the method and updates the locations that call that method to
pass it along.