### PR TITLE
Allow a user to override the ssh key data.

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -602,10 +602,12 @@ module FogDriver
     def ssh_options_for(machine_spec, machine_options, server)
       result = {
         :auth_methods => [ 'publickey' ],
-        :keys_only => true,
         :host_key_alias => "#{server.id}.#{provider}"
       }.merge(machine_options[:ssh_options] || {})
-      result[:key_data] = [ private_key_for(machine_spec, server) ]
+      unless result.key?(:key_data)
+        result[:keys_only] = true
+        result[:key_data] = [ private_key_for(machine_spec, machine_options, server) ]
+      end
       result
     end
 


### PR DESCRIPTION
This allows a user to set the ssh key data that they would like to use
as well as tell the fog_driver to not read the key data. For example the
following tells the driver to not load the key data and allows your ssh
key negotiation to be done with an ssh agent where you may have already
unlocked your keys:

```ruby
with_machine_options(ssh_options: { key_data: [] })
```