### PR TITLE
Support for ~/.aws/credentials

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -53,8 +53,8 @@ module FogDriver
   # from_provider and compute_options_for, and add the new provider in the case
   # statements so that URLs for your fog provider can be generated.  If your
   # cloud provider has environment variables or standard config files (like
-  # ~/.aws/config), you can read those and merge that information in the
-  # compute_options_for function.
+  # ~/.aws/credentials or ~/.aws/config), you can read those and merge that information
+  # in the compute_options_for function.
   #
   # ## Location format
   #
@@ -155,7 +155,7 @@ module FogDriver
     # config - configuration.  :driver_options, :keys, :key_paths and :log_level are used.
     #   driver_options is a hash with these possible options:
     #   - compute_options: the hash of options to Fog::Compute.new.
-    #   - aws_config_file: aws config file (default: ~/.aws/config)
+    #   - aws_config_file: aws config file (defaults: ~/.aws/credentials, ~/.aws/config)
     #   - aws_csv_file: aws csv credentials file downloaded from EC2 interface
     #   - aws_profile: profile name to use for credentials
     #   - aws_credentials: AWSCredentials object. (will be created for you by default)

--- a/lib/chef/provisioning/fog_driver/providers/aws.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws.rb
@@ -227,7 +227,7 @@ module FogDriver
           aws_profile = find_aws_profile_for_account_id(aws_credentials, aws_account_id, default_iam_endpoint)
         end
 
-        fail 'No AWS profile specified! Are you missing something in the Chef config or ~/.aws/config?' unless aws_profile
+        fail 'No AWS profile specified! Are you missing something in the Chef or AWS config?' unless aws_profile
 
         aws_profile[:ec2_endpoint] ||= default_ec2_endpoint
         aws_profile[:iam_endpoint] ||= default_iam_endpoint
@@ -256,7 +256,7 @@ module FogDriver
         if aws_profile
           Chef::Log.info("Discovered AWS profile #{aws_profile[:name]} pointing at account #{aws_account_id}.  Using ...")
         else
-          raise "No AWS profile leads to account ##{aws_account_id}.  Do you need to add profiles to ~/.aws/config?"
+          raise "No AWS profile leads to account #{aws_account_id}.  Do you need to add profiles to the AWS config?"
         end
         aws_profile
       end

--- a/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
@@ -67,10 +67,10 @@ module FogDriver
         end
 
         def load_default
-          unless ENV['AWS_CONFIG_FILE']
-            path = ['~/.aws/config', '~/.aws/credentials']
-          else
+          if ENV['AWS_CONFIG_FILE']
             path = [ENV['AWS_CONFIG_FILE']]
+          else
+            path = ['~/.aws/config', '~/.aws/credentials']
           end
 
           path.each do |file|

--- a/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
@@ -68,7 +68,7 @@ module FogDriver
 
         def load_default
           unless ENV['AWS_CONFIG_FILE']
-            path = ['~/.aws/credentials', '~/.aws/config']
+            path = ['~/.aws/config', '~/.aws/credentials']
           else
             path = [ENV['AWS_CONFIG_FILE']]
           end

--- a/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws/credentials.rb
@@ -1,5 +1,6 @@
 require 'inifile'
 require 'csv'
+require 'chef/mixin/deep_merge'
 
 class Chef
 module Provisioning
@@ -13,6 +14,7 @@ module FogDriver
         end
 
         include Enumerable
+        include Chef::Mixin::DeepMerge
 
         def default
           if @credentials.size == 0
@@ -33,8 +35,16 @@ module FogDriver
           @credentials.each(&block)
         end
 
-        def load_ini(credentials_ini_file)
-          inifile = IniFile.load(File.expand_path(credentials_ini_file))
+        def load_inis(config_ini_file, credentials_ini_file = nil)
+          @credentials = load_config_ini(config_ini_file)
+          @credentials = deep_merge!(@credentials,
+                                     load_credentials_ini(credentials_ini_file)
+                                    ) if credentials_ini_file
+        end
+
+        def load_config_ini(config_ini_file)
+          inifile = IniFile.load(File.expand_path(config_ini_file))
+          config = {}
           if inifile
             inifile.each_section do |section|
               if section =~ /^\s*profile\s+(.+)$/ || section =~ /^\s*(default)\s*/
@@ -44,15 +54,27 @@ module FogDriver
                   result
                 end
                 profile[:name] = profile_name
-                @credentials[profile_name] = (@credentials[profile_name].nil? && profile) ||
-                    @credentials[profile_name].merge(profile)
+                config[profile_name] = profile
               end
             end
-          else
-            # Get it to throw an error
-            File.open(File.expand_path(credentials_ini_file)) do
+          end
+          config
+        end
+
+        def load_credentials_ini(credentials_ini_file)
+          inifile = IniFile.load(File.expand_path(credentials_ini_file))
+          config = {}
+          if inifile
+            inifile.each_section do |section|
+              profile = inifile[section].inject({}) do |result, pair|
+                result[pair[0].to_sym] = pair[1]
+                result
+              end
+              profile[:name] = section
+              config[section] = profile
             end
           end
+          config
         end
 
         def load_csv(credentials_csv_file)
@@ -67,15 +89,13 @@ module FogDriver
         end
 
         def load_default
-          if ENV['AWS_CONFIG_FILE']
-            path = [ENV['AWS_CONFIG_FILE']]
-          else
-            path = ['~/.aws/config', '~/.aws/credentials']
-          end
-
-          path.each do |file|
-            if File.file?(File.expand_path(file))
-              load_ini(file)
+          config_file = ENV['AWS_CONFIG_FILE'] || File.expand_path('~/.aws/config')
+          credentials_file = ENV['AWS_CREDENTIAL_FILE'] || File.expand_path('~/.aws/credentials')
+          if File.file?(config_file)
+            if File.file?(credentials_file)
+              load_inis(config_file, credentials_file)
+            else
+              load_inis(config_file)
             end
           end
         end


### PR DESCRIPTION
Initial support for fetching the aws_access_key_id and aws_secret_access_key from `~/.aws/credentials` instead of `~/.aws/config`.

This will merge both ini files since currently we're storing the region in the `@credentials` hash as well.

Should solve #41.