### PR TITLE
Fix exception when setting convergence options

### DIFF
--- a/lib/chef/provisioning/fog_driver/providers/aws.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws.rb
@@ -167,8 +167,8 @@ module FogDriver
       end
 
       def convergence_strategy_for(machine_spec, machine_options)
-        machine_options[:convergence_options] ||= {}
-        machine_options[:convergence_options][:ohai_hints] = { 'ec2' => ''}
+        machine_options.configs << {
+          :convergence_options => { :ohai_hints => { 'ec2' => ''} } }
         super(machine_spec, machine_options)
       end
 


### PR DESCRIPTION
Fixes #78

The issue occurs because machine_options is a MergedConfig object, which
contains multiple hashes that get merged on lookup. This object is  immutable,
but it only returns MergedConfig objects if it has to, and returns normal
hashes if no merging actually needs to happen.

This means that if you don't provide your own convergence_options, then only
one version of convergence_options is present (the options specifying which
chef server to use), and so when the aws fog provider tries to modify
it, there's no issue because it's modifying a hash.

However, if you provide your own convergence_options (e.g. for chef version or
bootstrap_proxy), then suddenly there are multiple versions of the key
present, and an immutable MergedConfig object is returned instead.

This change just adds another hash to the MergedConfig object, so when
everything gets merged, the ohai_hints value will be present as desired.