### PR TITLE
My stab at floating IP support

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -200,12 +200,13 @@ module FogDriver
         raise "Machine #{machine_spec.name} does not have a server associated with it, or server does not exist."
       end
 
-      # Attach floating IPs if necessary
-      attach_floating_ips(action_handler, machine_spec, machine_options, server)
-
       # Start the server if needed, and wait for it to start
       start_server(action_handler, machine_spec, server)
       wait_until_ready(action_handler, machine_spec, machine_options, server)
+
+      # Attach floating IPs if necessary
+      attach_floating_ips(action_handler, machine_spec, machine_options, server)
+
       begin
         wait_for_transport(action_handler, machine_spec, machine_options, server)
       rescue Fog::Errors::TimeoutError

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -426,24 +426,25 @@ module FogDriver
     end
 
     # Check given IP already attached and attach if necessary
-    # TODO update to remove old floating IPs
+    # TODO update to remove old floating IPs that should not be assigned to machine
     def attach_floating_ips(action_handler, machine_spec, machine_options, server)
       pool = option_for(machine_options, :floating_ip_pool)
       floating_ip = option_for(machine_options, :floating_ip)
       if pool
+
         Chef::Log.info 'Attaching IP from pool'
-        allocated_addresses = server.addresses[pool]
-        unless allocated_addresses.nil?
-          floating_ips = allocated_addresses.select {|a_info| a_info['OS-EXT-IPS:type']=='floating'}
-          if floating_ips.length>0
-            Chef::Log.info "Server already assigned floating_ips `#{floating_ips}` from pool `#{pool}`"
-          end
-        else
+        allocated_addresses = server.addresses[pool] || []
+        floating_ips = allocated_addresses.select {|a_info| a_info['OS-EXT-IPS:type']=='floating'}
+        if floating_ips.size > 0
+          Chef::Log.info "Server already assigned floating_ips `#{floating_ips}` from pool `#{pool}`"
+        elsif
           action_handler.perform_action "Attaching floating IP from pool `#{pool}`" do
             attach_ip_from_pool(server, pool)
           end
         end
+
       elsif floating_ip
+
         Chef::Log.info 'Attaching given IP'
         allocated_addresses = []
         server.addresses.keys.each do |pool|
@@ -456,6 +457,7 @@ module FogDriver
             attach_ip(server, floating_ip)
           end
         end
+
       end
     end
 

--- a/lib/chef/provisioning/fog_driver/providers/aws.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws.rb
@@ -173,6 +173,14 @@ module FogDriver
         super(machine_spec, machine_options)
       end
 
+      # Attach given IP to machine
+      def attach_ip(server, ip)
+        Chef::Log.info "Attaching floating IP <#{ip}>"
+        compute.associate_address(:instance_id => server.id,
+                                  :allocation_id =>  option_for(machine_options, :allocation_id),
+                                  :public_ip => ip)
+      end
+
       def self.get_aws_profile(driver_options, aws_account_id)
         aws_credentials = get_aws_credentials(driver_options)
         compute_options = driver_options[:compute_options] || {}


### PR DESCRIPTION
I updated the `attach_ip` calls to use the correct parameters.  AWS was the only one who wanted an `allocation_id` so I made that specific to AWS.  I _think_ the only other consumer of floating IPs is Openstack (according to Fog), so the rest of the code I tested with Openstack.

I would love some more testing on this - my openstack instance is local and it is... flaky :)

I also added some minor bug fixes like:
* Moved the Mutex to a class variable because `||=` is not thread safe
* Pulled in the changes from https://github.com/chef/chef-provisioning-fog/pull/47 to make IP assignment Idempotent
  * IP removal is not supported yet - TODO

Replaces https://github.com/chef/chef-provisioning-fog/pull/69
Replaces https://github.com/chef/chef-provisioning-fog/pull/47
Fixes https://github.com/chef/chef-provisioning-fog/issues/77
Fixes https://github.com/chef/chef-provisioning-fog/issues/76
\cc @jkeiser @ryancragun @thommay @vills