### PR TITLE
Solve NoMethodError for fog providers that do not provide the 'addresses' method to the 'server' object

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -469,18 +469,13 @@ module FogDriver
     # Find all attached floating IPs from all networks
     def find_floating_ips(server)
       floating_ips = []
-      begin
-	      server.addresses.each do |network, addrs|
-	        addrs.each do | full_addr |
-	          if full_addr['OS-EXT-IPS:type'] == 'floating'
-	            floating_ips << full_addr['addr']
-	          end
-	        end
-	      end
-      rescue NoMethodError
-		  # Some fog providers (e.g. Joyent) do not have the 'addresses' method
+      server.addresses.each do |network, addrs|
+        addrs.each do | full_addr |
+          if full_addr['OS-EXT-IPS:type'] == 'floating'
+            floating_ips << full_addr['addr']
+          end
+        end
       end
-
       floating_ips
     end
 

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -469,13 +469,18 @@ module FogDriver
     # Find all attached floating IPs from all networks
     def find_floating_ips(server)
       floating_ips = []
-      server.addresses.each do |network, addrs|
-        addrs.each do | full_addr |
-          if full_addr['OS-EXT-IPS:type'] == 'floating'
-            floating_ips << full_addr['addr']
-          end
-        end
+      begin
+	      server.addresses.each do |network, addrs|
+	        addrs.each do | full_addr |
+	          if full_addr['OS-EXT-IPS:type'] == 'floating'
+	            floating_ips << full_addr['addr']
+	          end
+	        end
+	      end
+      rescue NoMethodError
+		  # Some fog providers (e.g. Joyent) do not have the 'addresses' method
       end
+
       floating_ips
     end
 

--- a/lib/chef/provisioning/fog_driver/providers/joyent.rb
+++ b/lib/chef/provisioning/fog_driver/providers/joyent.rb
@@ -27,6 +27,10 @@ module FogDriver
         bootstrap_options
       end
 
+      def find_floating_ips(server)
+        []
+      end
+
       def self.compute_options_for(provider, id, config)
         new_compute_options = {}
         new_compute_options[:provider] = provider

--- a/lib/chef/provisioning/fog_driver/providers/joyent.rb
+++ b/lib/chef/provisioning/fog_driver/providers/joyent.rb
@@ -27,7 +27,7 @@ module FogDriver
         bootstrap_options
       end
 
-      def find_floating_ips(server)
+      def find_floating_ips(server, action_handler)
         []
       end
 


### PR DESCRIPTION
see https://apidocs.joyent.com/cloudapi/#CreateMachine