### PR TITLE
Adds a provider to support Google cloud

### DIFF
--- a/lib/chef/provisioning/fog_driver/providers/google.rb
+++ b/lib/chef/provisioning/fog_driver/providers/google.rb
@@ -1,0 +1,76 @@
+class Chef
+  module Provisioning
+    module FogDriver
+      module Providers
+        class Google < FogDriver::Driver
+          Driver.register_provider_class('Google', FogDriver::Providers::Google)
+
+          def creator
+            ''
+          end
+
+          def converge_floating_ips(action_handler, machine_spec, machine_options, server)
+          end
+
+          def server_for(machine_spec)
+            if machine_spec.name
+              compute.servers.get(machine_spec.name)
+            else
+              nil
+            end
+          end
+
+          def bootstrap_options_for(action_handler, machine_spec, machine_options)
+            bootstrap_options = symbolize_keys(machine_options[:bootstrap_options] || {})
+            bootstrap_options[:image_name] = 'debian-7-wheezy-v20150325'
+            bootstrap_options[:machine_type] = 'n1-standard-1'
+            bootstrap_options[:zone_name] = 'europe-west1-b'
+            bootstrap_options[:name] = machine_spec.name
+
+            if bootstrap_options[:disks].nil?
+              # create the persistent boot disk
+              disk_defaults = {
+                :name => machine_spec.name,
+                :size_gb => 10,
+                :zone_name => bootstrap_options[:zone_name],
+                :source_image => bootstrap_options[:image_name],
+              }
+
+              disk = compute.disks.create(disk_defaults)
+              disk.wait_for { disk.ready? }
+              bootstrap_options[:disks] = [disk]
+            end
+
+            bootstrap_options
+          end
+
+          def destroy_machine(action_handler, machine_spec, machine_options)
+            server = server_for(machine_spec)
+            if server && server.state != 'archive'
+              action_handler.perform_action "destroy machine #{machine_spec.name} (#{machine_spec.location['server_id']} at #{driver_url})" do
+                server.destroy
+              end
+            end
+            machine_spec.location = nil
+            strategy = convergence_strategy_for(machine_spec, machine_options)
+            strategy.cleanup_convergence(action_handler, machine_spec)
+          end
+
+          def self.compute_options_for(provider, id, config)
+            new_compute_options = {}
+            new_compute_options[:provider] = provider
+            new_config = { :driver_options => { :compute_options => new_compute_options }}
+            new_defaults = {
+              :driver_options  => { :compute_options => {} },
+              :machine_options => { :bootstrap_options => {}, :ssh_options => {} }
+            }
+            result = Cheffish::MergedConfig.new(new_config, config, new_defaults)
+
+            [result, '']
+          end
+
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here comes a simple provider to be able to use chef-provisioning-fog with Google cloud.

I've been able to spin-up machine and made them converge with this provider.

Looking forward any feedback.