### PR TITLE
Implement Retryable to fix RequestLimitExceeded error from Fog::Compute::AWS::Error

### DIFF
--- a/chef-provisioning-fog.gemspec
+++ b/chef-provisioning-fog.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cheffish', '>= 0.4'
   s.add_dependency 'chef-provisioning', '~> 1.0'
   s.add_dependency 'fog'
+  s.add_dependency 'retryable'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -407,7 +407,7 @@ module FogDriver
       if !server.ready?
         if action_handler.should_perform_actions
           Retryable.retryable(RETRYABLE_OPTIONS) do |retries,exception|
-            action_handler.report_progress "waiting for #{machine_spec.name} (#{server.id} on #{driver_url}) to be ready, attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
+            action_handler.report_progress "waiting for #{machine_spec.name} (#{server.id} on #{driver_url}) to be ready, API attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
             server.wait_for(remaining_wait_time(machine_spec, machine_options)) { ready? }
           end
           action_handler.report_progress "#{machine_spec.name} is now ready"
@@ -476,7 +476,7 @@ module FogDriver
     def find_floating_ips(server, action_handler)
       floating_ips = []
       Retryable.retryable(RETRYABLE_OPTIONS) do |retries,exception|
-        action_handler.report_progress "Querying for available floating IPs, attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
+        action_handler.report_progress "Querying for floating IPs attached to server #{server.id}, API attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
         server.addresses.each do |network, addrs|
           addrs.each do | full_addr |
             if full_addr['OS-EXT-IPS:type'] == 'floating'

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -19,6 +19,7 @@ require 'fog/compute'
 require 'socket'
 require 'etc'
 require 'time'
+require 'retryable'
 require 'cheffish/merged_config'
 require 'chef/provisioning/fog_driver/recipe_dsl'
 
@@ -403,7 +404,9 @@ module FogDriver
       if !server.ready?
         if action_handler.should_perform_actions
           action_handler.report_progress "waiting for #{machine_spec.name} (#{server.id} on #{driver_url}) to be ready ..."
-          server.wait_for(remaining_wait_time(machine_spec, machine_options)) { ready? }
+          Retryable.retryable(:tries => 12, :sleep => 5, :on => [Fog::Compute::AWS::Error]) do
+            server.wait_for(remaining_wait_time(machine_spec, machine_options)) { ready? }
+          end
           action_handler.report_progress "#{machine_spec.name} is now ready"
         end
       end
@@ -469,10 +472,12 @@ module FogDriver
     # Find all attached floating IPs from all networks
     def find_floating_ips(server)
       floating_ips = []
-      server.addresses.each do |network, addrs|
-        addrs.each do | full_addr |
-          if full_addr['OS-EXT-IPS:type'] == 'floating'
-            floating_ips << full_addr['addr']
+      Retryable.retryable(:tries => 12, :sleep => 5, :on => [Fog::Compute::AWS::Error]) do
+        server.addresses.each do |network, addrs|
+          addrs.each do | full_addr |
+            if full_addr['OS-EXT-IPS:type'] == 'floating'
+              floating_ips << full_addr['addr']
+            end
           end
         end
       end

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -420,12 +420,14 @@ module FogDriver
       transport = transport_for(machine_spec, machine_options, server, action_handler)
       if !transport.available?
         if action_handler.should_perform_actions
-          action_handler.report_progress "waiting for #{machine_spec.name} (#{server.id} on #{driver_url}) to be connectable (transport up and running) ..."
+          Retryable.retryable(RETRYABLE_OPTIONS) do |retries,exception|
+            action_handler.report_progress "waiting for #{machine_spec.name} (#{server.id} on #{driver_url}) to be connectable (transport up and running), API attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
 
-          _self = self
+            _self = self
 
-          server.wait_for(remaining_wait_time(machine_spec, machine_options)) do
-            transport.available?
+            server.wait_for(remaining_wait_time(machine_spec, machine_options)) do
+              transport.available?
+            end
           end
           action_handler.report_progress "#{machine_spec.name} is now connectable"
         end


### PR DESCRIPTION
based on the suggestion from: https://github.com/chef/chef-provisioning-aws/issues/158#issuecomment-102196075

We could expand this to handle transient API errors from other cloud providers as well in future PRs.

cc: @tyler-ball 