### PR TITLE
Implementation of create_winrm_transport for OpenStack provider

### DIFF
--- a/lib/chef/provisioning/fog_driver/providers/openstack.rb
+++ b/lib/chef/provisioning/fog_driver/providers/openstack.rb
@@ -12,7 +12,7 @@ module FogDriver
       end
 
       def create_winrm_transport(machine_spec, machine_options, server)
-        remote_host = if machine_spec.location['use_private_ip_for_ssh']
+        remote_host = if machine_spec.reference['use_private_ip_for_ssh']
                         server.private_ip_address
                       elsif !server.public_ip_address
                         Chef::Log.warn("Server #{machine_spec.name} has no public ip address.  Using private ip '#{server.private_ip_address}'.  Set driver option 'use_private_ip_for_ssh' => true if this will always be the case ...")
@@ -24,16 +24,16 @@ module FogDriver
                       end
 		Chef::Log::info("Connecting to server #{remote_host}")
 		
-        port = machine_spec.location['winrm_port'] || 5985
+        port = machine_spec.reference['winrm_port'] || 5985
         endpoint = "http://#{remote_host}:#{port}/wsman"
         type = :plaintext
-        decrypted_password = machine_options[:adminPassword]
+        decrypted_password = machine_spec.reference['winrm.password'] 
 
         # Use basic HTTP auth - this is required for the WinRM setup we
         # are using
         # TODO: Improve that.
         options = {
-            :user => machine_spec.location['winrm.username'] || 'Administrator',
+            :user => machine_spec.reference['winrm.username'] || 'Administrator',
             :pass => decrypted_password,
             :disable_sspi => false,
             :basic_auth_only => true

--- a/lib/chef/provisioning/fog_driver/providers/openstack.rb
+++ b/lib/chef/provisioning/fog_driver/providers/openstack.rb
@@ -11,6 +11,37 @@ module FogDriver
         compute_options[:openstack_username]
       end
 
+      def create_winrm_transport(machine_spec, machine_options, server)
+        remote_host = if machine_spec.location['use_private_ip_for_ssh']
+                        server.private_ip_address
+                      elsif !server.public_ip_address
+                        Chef::Log.warn("Server #{machine_spec.name} has no public ip address.  Using private ip '#{server.private_ip_address}'.  Set driver option 'use_private_ip_for_ssh' => true if this will always be the case ...")
+                        server.private_ip_address
+                      elsif server.public_ip_address
+                        server.public_ip_address
+                      else
+                        fail "Server #{server.id} has no private or public IP address!"
+                      end
+		Chef::Log::info("Connecting to server #{remote_host}")
+		
+        port = machine_spec.location['winrm_port'] || 5985
+        endpoint = "http://#{remote_host}:#{port}/wsman"
+        type = :plaintext
+        decrypted_password = machine_options[:adminPassword]
+
+        # Use basic HTTP auth - this is required for the WinRM setup we
+        # are using
+        # TODO: Improve that.
+        options = {
+            :user => machine_spec.location['winrm.username'] || 'Administrator',
+            :pass => decrypted_password,
+            :disable_sspi => false,
+            :basic_auth_only => true
+        }
+
+        Chef::Provisioning::Transport::WinRM.new(endpoint, type, options, {})
+      end
+
       def self.compute_options_for(provider, id, config)
         new_compute_options = {}
         new_compute_options[:provider] = provider


### PR DESCRIPTION
Right now, you cannot create a windows image on OpenStack. The OpenStack provider lacks an implementation of create_winrm_transport.

I added a machine_option[:adminPassword] which contains the admin password for the image.
Other than that, it works just like the create_winrm_transport implementation for the aws provider