### PR TITLE
Fog, vCloud Air, OpenStack, DigitalOcean, edit re: chef-metal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 
 ## 0.7 (7/8/2014)
 
-- [AWS] More parallelism: make single call to AWS bootstrap many machines (if fog version supports it)
+- [AWS] More parallelism: make single call to AWS bootstrap many machines (if Fog version supports it)
 - [AWS] Fix bug when ~/.aws/config does not exist
 - [AWS] Fix bug in Ruby 1.9 when fingerprints don't match (pkcs8 loading didn't work)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # chef-provisioning-fog
 
-This is the Fog driver for Chef Provisioning.  It provides EC2, Rackspace, DigitalOcean, SoftLayer, Openstack, and vCAir functionality.
+This is the Fog driver for Chef Provisioning.  It provides Amazon EC2, Rackspace, DigitalOcean, SoftLayer, OpenStack, and vCloud Air functionality.

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -52,7 +52,7 @@ module FogDriver
   #
   # To add a new supported Fog provider, pick an appropriate identifier, go to
   # from_provider and compute_options_for, and add the new provider in the case
-  # statements so that URLs for your fog provider can be generated.  If your
+  # statements so that URLs for your Fog provider can be generated.  If your
   # cloud provider has environment variables or standard config files (like
   # ~/.aws/credentials or ~/.aws/config), you can read those and merge that information
   # in the compute_options_for function.
@@ -60,7 +60,7 @@ module FogDriver
   # ## Location format
   #
   # All machines have a location hash to find them.  These are the keys used by
-  # the fog provisioner:
+  # the Fog provisioner:
   #
   # - driver_url: fog:<driver>:<unique_account_info>
   # - server_id: the ID of the server so it can be found again
@@ -153,7 +153,7 @@ module FogDriver
       Provisioning.driver_for_url(driver_url, config)
     end
 
-    # Create a new fog driver.
+    # Create a new Fog driver.
     #
     # ## Parameters
     # driver_url - URL of driver.  "fog:<provider>:<provider_id>"
@@ -284,7 +284,7 @@ module FogDriver
     end
 
     def creator
-      raise "unsupported fog provider #{provider} (please implement #creator)"
+      raise "unsupported Fog provider #{provider} (please implement #creator)"
     end
 
     def create_servers(action_handler, specs_and_options, parallelizer, &block)
@@ -701,7 +701,7 @@ module FogDriver
     end
 
     def self.compute_options_for(provider, id, config)
-      raise "unsupported fog provider #{provider}"
+      raise "unsupported Fog provider #{provider}"
     end
   end
 end

--- a/lib/chef/provisioning/fog_driver/providers/aws.rb
+++ b/lib/chef/provisioning/fog_driver/providers/aws.rb
@@ -36,7 +36,7 @@ module FogDriver
         remote_host = if machine_spec.location['use_private_ip_for_ssh']
                         server.private_ip_address
                       elsif !server.public_ip_address
-                        Chef::Log.warn("Server #{machine_spec.name} has no public ip address.  Using private ip '#{server.private_ip_address}'.  Set driver option 'use_private_ip_for_ssh' => true if this will always be the case ...")
+                        Chef::Log.warn("Server #{machine_spec.name} has no public IP address.  Using private IP '#{server.private_ip_address}'.  Set driver option 'use_private_ip_for_ssh' => true if this will always be the case ...")
                         server.private_ip_address
                       elsif server.public_ip_address
                         server.public_ip_address
@@ -349,7 +349,7 @@ module FogDriver
               id = $1
               new_compute_options[:region] = $3
             else
-              Chef::Log.warn("Old-style AWS URL #{id} from an early beta of chef-metal (before 0.11-final) found. If you have servers in multiple regions on this account, you may see odd behavior like servers being recreated. To fix, edit any nodes with attribute chef_provisioning.location.driver_url to include the region like so: fog:AWS:#{id}:<region> (e.g. us-east-1)")
+              Chef::Log.warn("Old-style AWS URL #{id} from an early beta of chef-provisioning (before chef-metal 0.11-final) found. If you have servers in multiple regions on this account, you may see odd behavior like servers being recreated. To fix, edit any nodes with attribute chef_provisioning.location.driver_url to include the region like so: fog:AWS:#{id}:<region> (e.g. us-east-1)")
             end
           else
             # Assume it is a profile name, and set that.
@@ -384,7 +384,7 @@ module FogDriver
       end
 
       def create_many_servers(num_servers, bootstrap_options, parallelizer)
-        # Create all the servers in one request if we have a version of fog that can do that
+        # Create all the servers in one request if we have a version of Fog that can do that
         if compute.servers.respond_to?(:create_many)
           servers = compute.servers.create_many(num_servers, num_servers, bootstrap_options)
           if block_given?

--- a/lib/chef/provisioning/fog_driver/providers/digitalocean.rb
+++ b/lib/chef/provisioning/fog_driver/providers/digitalocean.rb
@@ -11,7 +11,7 @@ module FogDriver
       end
 
       def converge_floating_ips(action_handler, machine_spec, machine_options, server)
-        # Digital ocean does not have floating IPs
+        # DigitalOcean does not have floating IPs
       end
 
       def bootstrap_options_for(action_handler, machine_spec, machine_options)

--- a/lib/chef/provisioning/fog_driver/providers/vcair.rb
+++ b/lib/chef/provisioning/fog_driver/providers/vcair.rb
@@ -92,13 +92,13 @@ class Chef
             # If it is stopping, wait for it to get out of "stopping" transition state before starting
             if server.status == 'stopping'
               action_handler.report_progress "wait for #{machine_spec.name} (#{server.id} on #{driver_url}) to finish stopping ..."
-              # Vcair
-              # NOTE: Vcair fog does not get server.status via http every time
+              # vCloud Air
+              # NOTE: vCloud Air Fog does not get server.status via http every time
               server.wait_for { server.reload ; server.status != 'stopping' }
               action_handler.report_progress "#{machine_spec.name} is now stopped"
             end
 
-            # NOTE: Vcair fog does not get server.status via http every time
+            # NOTE: vCloud Air Fog does not get server.status via http every time
             server.reload
 
             if server.status == 'off' or server.status != 'on'
@@ -149,8 +149,8 @@ class Chef
             end
 
             remote_host = nil
-            # Vcair networking is funky
-            #if machine_options[:use_private_ip_for_ssh] # Vcair probably needs private ip for now
+            # vCloud Air networking is funky
+            #if machine_options[:use_private_ip_for_ssh] # vCloud Air probably needs private ip for now
             if server.ip_address
               remote_host = server.ip_address
             else
@@ -175,7 +175,7 @@ class Chef
             wait_until_ready(action_handler, machine_spec, machine_options, server)
 
             # Attach/detach floating IPs if necessary
-            # Vcair is funky for network.  vm has to be powered off or you get this error:
+            # vCloud Air is funky for network.  VM has to be powered off or you get this error:
             #    Primary NIC cannot be changed when the VM is not in Powered-off state
             # See code in update_network()
             #DISABLED: converge_floating_ips(action_handler, machine_spec, machine_options, server)
@@ -275,7 +275,7 @@ class Chef
               c.reset_password_required = true
             end
 
-            # TODO: Add support for admin_auto_logon to fog
+            # TODO: Add support for admin_auto_logon to Fog
             # c.admin_auto_logon_count = 100
             # c.admin_auto_logon_enabled = true
 
@@ -288,14 +288,14 @@ class Chef
             c.save
           end
 
-          ## Vcair
+          ## vCloud Air
           ## TODO: make work with floating_ip junk currently used
-          ## NOTE: current vcair networking changes require VM to be powered off
+          ## NOTE: current vCloud Air networking changes require VM to be powered off
           def update_network(bootstrap_options, vapp, vm)
             ## TODO: allow user to specify network to connect to (see above net used)
             # Define network connection for vm based on existing routed network
 
-            # Vcair inlining vapp() and vm()
+            # vCloud Air inlining vapp() and vm()
             #vapp = vdc.vapps.get_by_name(bootstrap_options[:name])
             #vm = vapp.vms.find {|v| v.vapp_name == bootstrap_options[:name]}
             nc = vapp.network_config.find { |n| n if n[:networkName].match(net.name) }
@@ -339,7 +339,7 @@ class Chef
 
           def destroy_machine(action_handler, machine_spec, machine_options)
             server = server_for(machine_spec)
-            if server && server.status != 'archive' # TODO: does Vcair do archive?
+            if server && server.status != 'archive' # TODO: does vCloud Air do archive?
               action_handler.perform_action "destroy machine #{machine_spec.name} (#{machine_spec.location['server_id']} at #{driver_url})" do
                 #NOTE: currently doing 1 vm for 1 vapp
                 vapp = vdc.vapps.get_by_name(machine_spec.name)

--- a/spec/unit/providers/rackspace_spec.rb
+++ b/spec/unit/providers/rackspace_spec.rb
@@ -8,7 +8,7 @@ describe Chef::Provisioning::FogDriver::Providers::Rackspace do
     expect(subject).to be_an_instance_of Chef::Provisioning::FogDriver::Providers::Rackspace
   end
 
-  it "has a fog backend" do
+  it "has a Fog backend" do
     pending unless Fog.mock?
     expect(subject.compute).to be_an_instance_of Fog::Compute::RackspaceV2::Mock
   end


### PR DESCRIPTION
Apply 3rd party names, consistently.

Also, put some context around a chef-metal warning to mention Chef provisioning.