### PR TITLE
All docs point to :bootstrap_options

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -280,7 +280,7 @@ module FogDriver
     protected
 
     def option_for(machine_options, key)
-      machine_options[key] || DEFAULT_OPTIONS[key]
+      machine_options[:bootstrap_options][key] || DEFAULT_OPTIONS[key]
     end
 
     def creator


### PR DESCRIPTION
In order for the machine_options to work you to pull from the hash,
`:bootstrap_options`. This adds it to the correct location so things you
declare get passed along. Take for instance the following:

```
with_machine_options({
                       :bootstrap_options => {
                         :flavor_ref  => 3,
                         :image_ref => 'A-fake-ref',
                         :nics => [{ :net_id => 'Another-fake-4006-ba81-89afddb9db6c'}],
                         :key_name => 'jdizzle',
                         :floating_ip_pool => 'ext-net'
                       },
                       :ssh_username => 'ubuntu'
                     })
```