### PR TITLE
Fix for #106

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -396,9 +396,9 @@ module FogDriver
 
     def remaining_wait_time(machine_spec, machine_options)
       if machine_spec.reference['started_at']
-        timeout = option_for(machine_options, :start_timeout) - (Time.now.utc - parse_time(machine_spec.reference['started_at']))
+        timeout = option_for(machine_options, :start_timeout) - (Time.now.to_i - parse_time(machine_spec.reference['started_at']))
       else
-        timeout = option_for(machine_options, :create_timeout) - (Time.now.utc - parse_time(machine_spec.reference['allocated_at']))
+        timeout = option_for(machine_options, :create_timeout) - (Time.now.to_i - parse_time(machine_spec.reference['allocated_at']))
       end
       timeout > 0 ? timeout : 0.01
     end


### PR DESCRIPTION
Fixes #106 

- Standardize on `Time.new.to_i` compared to `Time.new.utc`

It's good to be consistent ;)