### PR TITLE
Revert "Fix for #106"

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -396,9 +396,9 @@ module FogDriver
 
     def remaining_wait_time(machine_spec, machine_options)
       if machine_spec.reference['started_at']
-        timeout = option_for(machine_options, :start_timeout) - (Time.now.to_i - parse_time(machine_spec.reference['started_at']))
+        timeout = option_for(machine_options, :start_timeout) - (Time.now.utc - parse_time(machine_spec.reference['started_at']))
       else
-        timeout = option_for(machine_options, :create_timeout) - (Time.now.to_i - parse_time(machine_spec.reference['allocated_at']))
+        timeout = option_for(machine_options, :create_timeout) - (Time.now.utc - parse_time(machine_spec.reference['allocated_at']))
       end
       timeout > 0 ? timeout : 0.01
     end


### PR DESCRIPTION
Reverts chef/chef-provisioning-fog#133

It might be getting things consistent, but here we need to have a time to do computation on and not an int, as it leads to this error ->

```
Generated at 2015-10-27 17:58:13 +0100
TypeError: machine[test-machine] (test::test line 11) had an error: TypeError: Time can't be coerced into Fixnum
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-fog-0.15.1/lib/chef/provisioning/fog_driver/driver.rb:414:in `-'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-fog-0.15.1/lib/chef/provisioning/fog_driver/driver.rb:414:in `remaining_wait_time'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-fog-0.15.1/lib/chef/provisioning/fog_driver/driver.rb:432:in `block in wait_until_ready'
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/retryable-2.0.2/lib/retryable.rb:67:in `retryable'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-fog-0.15.1/lib/chef/provisioning/fog_driver/driver.rb:430:in `wait_until_ready'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-fog-0.15.1/lib/chef/provisioning/fog_driver/driver.rb:213:in `ready_machine'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-1.4.1/lib/chef/provider/machine.rb:39:in `block in <class:Machine>'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/provider.rb:362:in `action_ready'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-provisioning-1.4.1/lib/chef/provider/machine.rb:56:in `block in <class:Machine>'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/provider.rb:362:in `action_converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/provider.rb:144:in `run_action'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource.rb:585:in `run_action'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/runner.rb:49:in `run_action'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/runner.rb:81:in `each'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/runner.rb:81:in `block in converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/resource_list.rb:83:in `block in execute_each_resource'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/resource_collection/resource_list.rb:81:in `execute_each_resource'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/runner.rb:80:in `converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/client.rb:653:in `block in converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/client.rb:648:in `catch'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/client.rb:648:in `converge'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/client.rb:687:in `converge_and_save'
/home/kri5/.chefdk/gem/ruby/2.1.0/gems/chef-12.5.1/lib/chef/client.rb:269:in `run'
```

I propose to reverts the commit that prevents to use chef-provisionning-fog.