### PR TITLE
Adding rake:publish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,6 @@ group :development do
   gem 'guard'
   gem 'guard-rspec'
   gem 'rb-readline'
+  gem 'bump'
+  gem 'github_changelog_generator'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,3 @@
 source "https://rubygems.org"
 gemfile
 gemspec
-
-group :development do
-  gem 'chef'
-  gem 'chef-provisioning'
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'rb-readline'
-  gem 'bump'
-  gem 'github_changelog_generator'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,37 @@
 require 'bundler'
 require 'bundler/gem_tasks'
+require 'bump'
+require 'github_changelog_generator'
 
 task :spec do
   require File.expand_path('spec/run')
+end
+
+desc 'Sanity Checks and releases gem to rubygems'
+task :sanity do
+  # Bumps the version.rb patch version (there are gems that can handle this for us)
+  Rake::Task[:minor].invoke
+
+  # Runs github_changelog_generator to update the CHANGELOG.rb per the release guide
+  # need to figure out how to check for https://github.com/skywinder/github-changelog-generator#github-token
+  sh 'github_changelog_generator'
+
+  # Commits those as a change to master (git commit -am "Preparing the #{future_version} release" && git push)
+  future_version = Bump::Bump.current
+  sh "git commit -am 'Preparing for #{future_version} release' && git push"
+
+  # Runs git tag to take the release (git tag -a "Releasing #{future_version}" && git push --tags)
+  sh "git tag -a 'Releasing #{future_version}' && git push --tags"
+
+  # need to add rake release here :)
+end
+
+desc 'Does a patch bump to the gem'
+task :minor do
+  Bump::Bump.run("patch")
+end
+
+desc 'Does a minor bump to the gem'
+task :minor do
+  Bump::Bump.run("minor")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ task :sanity do
 end
 
 desc 'Does a patch bump to the gem'
-task :minor do
+task :patch do
   Bump::Bump.run("patch")
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,8 @@ task :spec do
   require File.expand_path('spec/run')
 end
 
-desc 'Sanity Checks and releases gem to rubygems'
-task :sanity do
+desc 'Bump minor version, create changelog, tag, push to github, and publish to rubygems.'
+task :publish do
   # Bumps the version.rb patch version (there are gems that can handle this for us)
   Rake::Task[:minor].invoke
 

--- a/chef-provisioning-fog.gemspec
+++ b/chef-provisioning-fog.gemspec
@@ -12,12 +12,18 @@ Gem::Specification.new do |s|
   s.email = ['jkeiser@getchef.com', 'hh@vulk.co', 't@vulk.co', 'w@vulk.co']
   s.homepage = 'https://github.com/opscode/chef-provisioning-fog'
 
+  s.add_dependnecy 'chef'
   s.add_dependency 'chef-provisioning', '~> 1.0'
   s.add_dependency 'fog'
   s.add_dependency 'retryable'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'guard'
+  s.add_development_dependency 'guard-rspec'
+  s.add_development_dependency 'rb-readline'
+  s.add_development_dependency 'bump'
+  s.add_development_dependency 'github_changelog_generator'
 
   s.bindir       = "bin"
   s.executables  = %w( )


### PR DESCRIPTION
This will allow for a release of what Tyler Ball want's as a standard
release process.

- Bumps the minor version
- runs github_changelog_generator
- commits the things to github
- _will_ push to rubygems...after everyone is cool with this PR.