### PR TITLE
destroy_machines should not fail when no server is found

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -244,7 +244,7 @@ module FogDriver
           machine_spec.reference = nil
         end
       end
-      strategy = convergence_strategy_for(machine_spec, machine_options)
+      strategy = ConvergenceStrategy::NoConverge.new(machine_options[:convergence_options], config)
       strategy.cleanup_convergence(action_handler, machine_spec)
     end
 


### PR DESCRIPTION
Issue #154: Explicity setting the strategy to NoConverge when destroying machines, even when the server was not found