### PR TITLE
Revert to using state instead of status

### DIFF
--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -297,7 +297,7 @@ module FogDriver
       specs_and_options.each do |machine_spec, machine_options|
         server = specs_and_servers[machine_spec]
         if server
-          if %w(terminated archive).include?(server.status) # Can't come back from that
+          if %w(terminated archive DELETED).include?(server.state) # Can't come back from that
             Chef::Log.warn "Machine #{machine_spec.name} (#{server.id} on #{driver_url}) is terminated.  Recreating ..."
           else
             yield machine_spec, server if block_given?
@@ -371,13 +371,13 @@ module FogDriver
 
     def start_server(action_handler, machine_spec, server)
       # If it is stopping, wait for it to get out of "stopping" transition status before starting
-      if server.status == 'stopping'
+      if server.state == 'stopping'
         action_handler.report_progress "wait for #{machine_spec.name} (#{server.id} on #{driver_url}) to finish stopping ..."
-        server.wait_for { server.status != 'stopping' }
+        server.wait_for { server.state != 'stopping' }
         action_handler.report_progress "#{machine_spec.name} is now stopped"
       end
 
-      if server.status == 'stopped'
+      if server.state == 'stopped'
         action_handler.perform_action "start machine #{machine_spec.name} (#{server.id} on #{driver_url})" do
           server.start
           machine_spec.reference['started_at'] = Time.now.to_i


### PR DESCRIPTION
I found it necessary to change this to .state as .status wasn't an attribute of Fog::Compute::Openstack::Server https://github.com/fog/fog/blob/master/lib/fog/openstack/models/compute/server.rb