### PR TITLE
Fix for google-api-client

### DIFF
--- a/chef-provisioning-fog.gemspec
+++ b/chef-provisioning-fog.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef-provisioning', '~> 1.0'
   s.add_dependency 'fog', '>= 1.35.0'
+  s.add_dependency 'google-api-client', "~> 0.8.0"
   s.add_dependency 'retryable'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
- This is a workaround to allow for chef-provisioning-fog to talk to google with the dependency gem google-api-client