### PR TITLE
Support for winrm_transport in openstack

### DIFF
--- a/lib/chef/provisioning/fog_driver/providers/openstack.rb
+++ b/lib/chef/provisioning/fog_driver/providers/openstack.rb
@@ -22,17 +22,7 @@ module FogDriver
         if machine_options[:winrm].nil?
           fail "You must provide winrm settings in machine_options to use the winrm transport!"
         end
-        remote_host = ''
-        if machine_spec.reference['use_private_ip_for_ssh']
-          remote_host = server.private_ip_address
-        elsif !server.public_ip_address
-          Chef::Log.warn("Server #{machine_spec.name} has no public ip address.  Using private ip '#{server.private_ip_address}'.  Set driver option 'use_private_ip_for_ssh' => true if this will always be the case ...")
-          remote_host = server.private_ip_address
-        elsif server.public_ip_address
-          remote_host = server.public_ip_address
-        else
-          fail "Server #{server.id} has no private or public IP address!"
-        end
+        remote_host = determine_remote_host machine_spec, server
         Chef::Log::info("Connecting to server #{remote_host}")
         port = machine_options[:winrm][:port] || 5985
         endpoint = "http://#{remote_host}:#{port}/wsman"
@@ -143,6 +133,32 @@ module FogDriver
           compute.images.get(image_spec.reference[:image_id]) || compute.images.get(image_spec.reference['image_id'])
         else
           nil
+        end
+      end
+
+      def determine_remote_host(machine_spec, server)
+        transport_address_location = (machine_spec.reference['transport_address_location'] || :none).to_sym
+
+        if machine_spec.reference['use_private_ip_for_ssh']
+          # The machine_spec has the old config key, lets update it - a successful chef converge will save the machine_spec
+          # TODO in 2.0 get rid of this update
+          machine_spec.reference.delete('use_private_ip_for_ssh')
+          machine_spec.reference['transport_address_location'] = :private_ip
+          server.private_ip_address
+        elsif transport_address_location == :ip_addresses
+          server.ip_addresses.first
+        elsif transport_address_location == :private_ip
+          server.private_ip_address
+        elsif transport_address_location == :public_ip
+          server.public_ip_address
+        elsif !server.public_ip_address && server.private_ip_address
+          Chef::Log.warn("Server #{machine_spec.name} has no public floating_ip address.  Using private floating_ip '#{server.private_ip_address}'.  Set driver option 'transport_address_location' => :private_ip if this will always be the case ...")
+          server.private_ip_address
+        elsif server.public_ip_address
+          server.public_ip_address
+        else
+          raise "Server #{server.id} has no private or public IP address!"
+          # raise "Invalid 'transport_address_location'.  They can only be 'public_ip', 'private_ip', or 'ip_addresses'."
         end
       end
 


### PR DESCRIPTION
First and formost, credit to @brumschlag, whose PR I took the majority of this code from.

I started a new PR because #109 seemed to be stagnant.  There were also a few issues that needed to be fixed (machine_spec.reference was not populated with the winrm settings, we don't want the winrm password in the machine_spec.reference as that will be added to the chef attributes in plain text, a few styling fixes, more configuration options).

Let me know if this is acceptable.  I'm also happy to use @brumschlag's branch if that's an option.  I don't want to discredit someone else's hard work.

I verified these changes on our openstack, everything worked as expected.