### PR TITLE
Add initial support for scaleway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemfile
 gemspec
 
 group :development do
-  gem "chef", git: "https://github.com/chef/chef" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.2") # until stable 12.14 is released (won't load new cheffish and such otherwise)
+  gem "chef"
   gem 'guard'
   gem 'guard-rspec'
   gem 'rb-readline'

--- a/README.md
+++ b/README.md
@@ -210,6 +210,24 @@ with_driver "fog:XenServer:<XEN-SERVER-IP/NAME>", compute_options: {
 
 For a full example see [examples/xenserver/simple.rb](examples/xenserver/simple.rb).
 
+### Scaleway
+
+You should configure the driver with your credentials or :
+
+``` ruby
+with_driver "fog:Scaleway:Your-Organisation-UUID:region", compute_options: {
+  scalewat_token: 'your-api-token',
+}
+```
+
+or just use the fog configuration (~/.fog):
+
+``` ruby
+with_driver 'fog:Scaleway'
+```
+
+For full examples, see [examples/scaleway](examples/scaleway).
+
 ### Cleaning up
 
 ```ruby

--- a/chef-provisioning-fog.gemspec
+++ b/chef-provisioning-fog.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'google-api-client', "~> 0.8.0"
   s.add_dependency 'fog-softlayer' , '~> 1.1.0'
   s.add_dependency 'fog-digitalocean'
+  s.add_dependency 'fog-scaleway'
   s.add_dependency 'retryable'
 
   s.add_development_dependency 'rspec'

--- a/examples/scaleway/no_ip.rb
+++ b/examples/scaleway/no_ip.rb
@@ -1,0 +1,17 @@
+require "chef/provisioning"
+
+# Using Fog's default credential storage
+with_driver "fog:Scaleway:my-org-uuid:par1"
+
+add_machine_options bootstrap_options: {
+  image: '3b522e7a-8468-4577-ab3e-2b9535384bb8', # Debian Sid / arm
+  commercial_type: "VC1S",
+}
+
+machine "no_ipv4" do
+  recipe 'apt'
+  add_machine_options: {
+    dynamic_ip_required: false,
+    enable_ipv6: true,
+  }
+end

--- a/examples/scaleway/select_public_ip.rb
+++ b/examples/scaleway/select_public_ip.rb
@@ -1,0 +1,27 @@
+require "chef/provisioning"
+
+# Using Fog's default credential storage
+with_driver "fog:Scaleway:my-org-uuid:ams1"
+
+add_machine_options bootstrap_options: {
+                      image: '3b522e7a-8468-4577-ab3e-2b9535384bb8', # Debian Sid / arm
+                      commercial_type: "VC1S",
+                    }
+
+machine "force_specific_address" do
+  recipe 'apt'
+  add_machine_options: {
+    name: 'another_server_name',
+    dynamic_ip_required: false,
+    # Must exist in your reserved IPs and be available
+    floating_ip: '1.2.3.4',
+  }
+end
+
+machine "grab_from_pool" do
+  recipe 'apt'
+  add_machine_options: {
+    dynamic_ip_required: false,
+    floating_ip_pool: 'global',
+  }
+end

--- a/examples/scaleway/simple.rb
+++ b/examples/scaleway/simple.rb
@@ -1,0 +1,29 @@
+require "chef/provisioning"
+
+# Using Fog's default credential storage
+with_driver "fog:Scaleway:my-org-uuid:region"
+
+# # Providing the credentials here (from a secure databag?)
+# with_driver "fog:Scaleway", compute_options: {
+#               scalewat_token: 'your-api-token',
+#             }
+
+add_machine_options bootstrap_options: {
+  # Images UUID can be obtained with the 'scw' tool.
+  # Ex: `scw images`, `scw inspect Debian_Sid` and `scw inspect 100a9904`
+  image: '599b736c-48b5-4530-9764-f04d06ecadc7', # Debian Sid / arm
+  commercial_type: "C1", # VC1S, ...
+
+  # The private key to use to connect and setup shef
+  # key_name: 'id_rsa',
+  # or directly the key path
+  # key_path: '/etc/chef/mykey.pem',
+  # More here: https://github.com/chef/chef-provisioning#machine-options
+}
+
+machine "myserver" do
+  recipe 'apt'
+  add_machine_options bootstrap_options: {
+    tags: ['forever_up'],
+  }
+end

--- a/examples/scaleway/volumes.rb
+++ b/examples/scaleway/volumes.rb
@@ -1,0 +1,20 @@
+require 'chef/provisioning'
+require 'chef/provisioning/fog_driver/recipe_dsl'
+
+with_driver('fog:Scaleway:7d1f7463-ffef-4669-ae1e-dfdbb1c50575:par1')
+
+
+scaleway_volume 'test-volume4' do
+  volume_options volume_type: 'l_ssd', size: 50000000000
+end
+
+machine 'machine_with_extra_volume' do
+  add_machine_options bootstrap_options: {
+                        commercial_type: 'C1',
+                        image: 'eeb73cbf-78a9-4481-9e38-9aaadaf8e0c9',
+                        dynamic_ip_required: false,
+                        volumes: {
+                          1 => { name: 'test-volume4' }
+                        }
+                      }
+end

--- a/lib/chef/provider/scaleway_volume.rb
+++ b/lib/chef/provider/scaleway_volume.rb
@@ -1,0 +1,53 @@
+require 'chef/provider/lwrp_base'
+require 'openssl'
+require 'chef/provisioning/chef_provider_action_handler'
+require 'chef/provisioning/chef_managed_entry_store'
+
+class Chef
+class Provider
+class ScalewayVolume < Chef::Provider::LWRPBase
+  provides :scaleway_volume
+
+  def action_handler
+    @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)
+  end
+
+  def load_current_resource
+  end
+
+  def whyrun_supported?
+    true
+  end
+
+  def volume_spec
+    @volume_spec ||= chef_managed_entry_store.get_or_new(:volume, new_resource.name)
+  end
+
+  # Get the driver specified in the resource
+  def new_driver
+    @new_driver ||= run_context.chef_provisioning.driver_for(new_resource.driver)
+  end
+
+  def chef_managed_entry_store
+    @chef_managed_entry_store ||= Provisioning.chef_managed_entry_store(new_resource.chef_server)
+  end
+
+
+  action :create do
+    unless volume_spec.reference && new_driver.volume_for(volume_spec)
+      new_driver.create_volume(action_handler, volume_spec,
+                               new_resource.volume_options)
+    end
+    new_resource.id = volume_spec.reference['id']
+  end
+
+  action :destroy do
+    if volume_spec.reference && volume_spec.reference['id']
+      new_driver.destroy_volume(action_handler, volume_spec,
+                                new_resource.volume_options)
+      volume_spec.delete(action_handler)
+    end
+  end
+end
+end
+end

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -277,6 +277,14 @@ module FogDriver
       end
     end
 
+    def create_volume(action_handler, volume_spec, volume_options)
+      raise "##create_volume not implemented in in #{self.class}"
+    end
+
+    def destroy_volume(action_handler, volume_spec, volume_options)
+      raise "##destroy_volume not implemented in in #{self.class}"
+    end
+
     protected
 
     def option_for(machine_options, key)
@@ -308,13 +316,13 @@ module FogDriver
           Chef::Log.warn "Machine #{machine_spec.name} (#{machine_spec.reference['server_id']} on #{driver_url}) no longer exists.  Recreating ..."
         end
 
-      machine_spec.reference ||= {}
-      machine_spec.reference.update(
-        'driver_url' => driver_url,
-        'driver_version' => FogDriver::VERSION,
-        'creator' => creator,
-        'allocated_at' => Time.now.to_i
-      )
+        machine_spec.reference ||= {}
+        machine_spec.reference.update(
+          'driver_url' => driver_url,
+          'driver_version' => FogDriver::VERSION,
+          'creator' => creator,
+          'allocated_at' => Time.now.to_i
+        )
 
         bootstrap_options = bootstrap_options_for(action_handler, machine_spec, machine_options)
         machine_spec.reference['key_name'] = bootstrap_options[:key_name] if bootstrap_options[:key_name]
@@ -368,6 +376,7 @@ module FogDriver
     def create_many_servers(num_servers, bootstrap_options, parallelizer)
       parallelizer.parallelize(1.upto(num_servers)) do |i|
         clean_bootstrap_options = Marshal.load(Marshal.dump(bootstrap_options)) # Prevent destructive operations on bootstrap_options.
+
         server = compute.servers.create(clean_bootstrap_options)
         yield server if block_given?
         server
@@ -613,6 +622,10 @@ module FogDriver
       else
         Machine::UnixMachine.new(machine_spec, transport_for(machine_spec, machine_options, server), convergence_strategy_for(machine_spec, machine_options))
       end
+    end
+
+    def volume_for(volume_spec)
+      raise "Immplement me in #{self.class.name}"
     end
 
     def convergence_strategy_for(machine_spec, machine_options)

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -483,7 +483,6 @@ module FogDriver
           end
           server.reload
         end
-
       end
     end
 

--- a/lib/chef/provisioning/fog_driver/providers/openstack.rb
+++ b/lib/chef/provisioning/fog_driver/providers/openstack.rb
@@ -48,7 +48,7 @@ module FogDriver
         result = Cheffish::MergedConfig.new(new_config, config, new_defaults)
 
         new_compute_options[:openstack_auth_url] = id if (id && id != '')
-        
+
         credential = Fog.credentials.find_all{ |k,v|
           k.to_s.start_with?('openstack') }
         credential.each { |k,v|

--- a/lib/chef/provisioning/fog_driver/providers/scaleway.rb
+++ b/lib/chef/provisioning/fog_driver/providers/scaleway.rb
@@ -1,0 +1,176 @@
+# fog:OpenStack:https://identifyhost:portNumber/v2.0
+
+require 'fog/scaleway'
+require 'fog/scaleway/models/compute/server'
+
+#
+# We're monkeypatching here to avoid overriding too much of the base
+# class. This monkey patch will be removed if we can merge those changes
+# upstream
+#
+class Fog::Scaleway::Compute::Server
+  alias :start :poweron
+  alias :stop :poweroff
+
+  def disassociate_address(ip)
+    ip = ip.address if ip.respond_to? :address
+    if public_ip && public_ip.address == ip
+      public_ip.server = nil
+      public_ip.save
+    end
+    reload
+  end
+end
+
+class Chef
+module Provisioning
+module FogDriver
+  module Providers
+    class Scaleway < FogDriver::Driver
+      Driver.register_provider_class('Scaleway', FogDriver::Providers::Scaleway)
+
+      def creator
+        compute_options[:scaleway_organization]
+      end
+
+      def convergence_strategy_for(machine_spec, machine_options)
+        machine_options = Cheffish::MergedConfig.new(machine_options, {
+                                                       :convergence_options => {:ohai_hints => {'scaleway' => {}}}
+                                                     })
+        super(machine_spec, machine_options)
+      end
+
+      def bootstrap_options_for(action_handler, machine_spec, machine_options)
+        opts = super
+        opts[:tags] = opts[:tags].map { |key, value| [key, value].join('=') }
+        opts
+      end
+
+
+      def destroy_machine(action_handler, machine_spec, machine_options)
+        server = server_for(machine_spec)
+        if server
+          action_handler.perform_action "destroy machine #{machine_spec.name} (#{machine_spec.reference['server_id']} at #{driver_url})" do
+
+            # Scaleway's API fail if we try to stop/terminate an instance with
+            # certains states
+            if server.state == 'running'
+              server.stop
+              server.wait_for { server.state != 'running' }
+            end
+            ['stopping', 'starting'].each do |state|
+              server.wait_for { server.state != state } if server.state == state
+            end
+
+            if server.state == 'stopped'
+              server.destroy
+            else
+              Chef::log.fatal "Server is in an unknown state (#{server.state})"
+            end
+            machine_spec.reference = nil
+          end
+        end
+        strategy = ConvergenceStrategy::NoConverge.new(machine_options[:convergence_options], config)
+        strategy.cleanup_convergence(action_handler, machine_spec)
+      end
+
+      def stop_machine(action_handler, machine_spec, machine_options)
+        server = server_for(machine_spec)
+        if server and server.state == 'running'
+          action_handler.perform_action "stop machine #{machine_spec.name} (#{server.id} at #{driver_url})" do
+            server.poweroff(true)
+            server.wait_for { server.state == 'stopped' }
+          end
+        end
+      end
+
+      def self.compute_options_for(provider, id, config)
+        new_compute_options = {}
+        new_compute_options[:provider] = provider
+        if (id && id != '')
+          org, region = id.split(':')
+          new_compute_options[:scaleway_organization] = org
+          new_compute_options[:scaleway_region] = region || 'par1'
+        end
+        new_config = { :driver_options => { :compute_options => new_compute_options }}
+
+        new_default_compute_options = {}
+        new_defaults = {
+          :driver_options => { :compute_options => new_default_compute_options },
+          :machine_options => { :bootstrap_options => {} }
+        }
+
+        result = Cheffish::MergedConfig.new(new_config, config, new_defaults)
+
+        credential = Fog.credentials
+        new_default_compute_options[:scaleway_organization] ||= credential[:scaleway_organization]
+        new_default_compute_options[:scaleway_token] ||= credential[:scaleway_token]
+
+        id = [result[:driver_options][:compute_options][:scaleway_organization],
+              result[:driver_options][:compute_options][:scaleway_region]].join(':')
+
+        [result, id]
+      end
+
+      def converge_floating_ips(action_handler, machine_spec, machine_options, server)
+        if server.dynamic_ip_required
+          Chef::Log.info "Dynamic IP allocation has been enabled, not converging IPs"
+        else
+          super
+        end
+      end
+
+      # Scaleway only has one global pool.
+      def attach_ip_from_pool(server, pool)
+        return server if server.public_ip
+
+        Chef::Log.info "Scaleway has only one IP pool, ignoring pool argument"
+        ip = server.service.ips.all.select { |ip| ip.address.nil? }.first
+        if ip
+          ip.server = server
+          ip.save
+          server.reload
+        else
+          # Allocate a new IP
+          ip = server.service.ips.create
+          ip.server = server
+          ip.save
+          server.reload
+        end
+      end
+
+      def attach_ip(server, floating_ip)
+        ip = server.service.ips.get(floating_ip)
+        if ip.nil?
+          raise RuntimeError, "Requested IP (#{floating_ip}) not found"
+        end
+        if ip.server and ip.server.identity != server.identity
+          raise RuntimeError, "Requested IP (#{floating_ip}) already attached"
+        end
+
+        if server.public_ip
+          old_ip = server.public_ip
+          Chef::Log.info "Server #{server.identity} already has IP #{old_ip.address}, removing it"
+          old_ip.server = nil
+          old_ip.save
+        end
+
+        ip.server = server
+        ip.save
+        server.reload
+      end
+
+      # Get the public IP if any
+      def find_floating_ips(server, action_handler)
+        public_ips = []
+        Retryable.retryable(RETRYABLE_OPTIONS) do |retries, _exception|
+          action_handler.report_progress "Querying for public IP attached to server #{server.id}, API attempt #{retries+1}/#{RETRYABLE_OPTIONS[:tries]} ..."
+          public_ips << server.public_ip.address if server.public_ip
+        end
+        public_ips
+      end
+    end
+  end
+end
+end
+end

--- a/lib/chef/provisioning/fog_driver/recipe_dsl.rb
+++ b/lib/chef/provisioning/fog_driver/recipe_dsl.rb
@@ -1,6 +1,8 @@
 require 'chef/provisioning/fog_driver/driver'
 require 'chef/resource/fog_key_pair'
 require 'chef/provider/fog_key_pair'
+require 'chef/resource/scaleway_volume'
+require 'chef/provider/scaleway_volume'
 
 class Chef
   module DSL
@@ -27,7 +29,7 @@ class Chef
         with_fog_driver('Vcair', driver_options, &block)
       end
 
-      def fog_scw_driver(driver_options = nil, &block)
+      def with_fog_scaleway_driver(driver_options = nil, &block)
         with_fog_driver('Scaleway', driver_options, &block)
       end
 

--- a/lib/chef/provisioning/fog_driver/recipe_dsl.rb
+++ b/lib/chef/provisioning/fog_driver/recipe_dsl.rb
@@ -27,6 +27,10 @@ class Chef
         with_fog_driver('Vcair', driver_options, &block)
       end
 
+      def fog_scw_driver(driver_options = nil, &block)
+        with_fog_driver('Scaleway', driver_options, &block)
+      end
+
     end
   end
 end

--- a/lib/chef/resource/scaleway_volume.rb
+++ b/lib/chef/resource/scaleway_volume.rb
@@ -1,0 +1,32 @@
+require 'chef/provisioning'
+
+class Chef::Resource::ScalewayVolume < Chef::Resource::LWRPBase
+  self.resource_name = 'scaleway_volume'
+
+  def initialize(*args)
+    super
+    @driver = run_context.chef_provisioning.current_driver
+    @chef_server = run_context.cheffish.current_chef_server
+  end
+
+  actions :create, :destroy, :nothing
+  default_action :create
+
+  attribute :id
+  attribute :chef_server
+  attribute :driver
+  attribute :volume_options
+
+  def add_volume_options(options)
+    if @volume_options
+      @volume_options = Cheffish::MergedConfig.new(options, @volume_options)
+    else
+      @volume_options = options
+    end
+  end
+
+  # We are not interested in Chef's cloning behavior here.
+  def load_prior_resource(*args)
+    Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
+  end
+end

--- a/spec/unit/providers/scaleway_spec.rb
+++ b/spec/unit/providers/scaleway_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'chef/provisioning/fog_driver/providers/scaleway'
+
+describe Chef::Provisioning::FogDriver::Providers::Scaleway do
+  subject do
+    Chef::Provisioning::FogDriver::Driver.from_provider(
+      'Scaleway', driver_options: { compute_options: {
+                                      scaleway_organization: 'org',
+                                      scaleway_token: 'key'}
+                                   }
+    )
+  end
+
+  it "returns the correct driver" do
+    expect(subject).to be_an_instance_of Chef::Provisioning::FogDriver::Providers::Scaleway
+  end
+
+  it "has a Fog backend" do
+    pending unless Fog.mock?
+    expect(subject.compute).to be_an_instance_of Fog::Scaleway::Compute::Mock
+  end
+
+  describe '#creator' do
+    it 'returns the organization' do
+      expect(subject.creator).to eq 'org'
+    end
+  end
+end


### PR DESCRIPTION
This PR adds initial support for [Scaleway](https://www.scaleway.com/) _cloud_ provider.

I've currently only played with the `machine` resource, but afaict it works reasonably well. It's nice to be able to provision from chef !

There isn't any serious unit testing done on this new driver as there wasn't any other driver's tests to base my tests on. I'd be happy to had some with some guidance/examples

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>