### PR TITLE
Fetch chef from Rubygems again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ gemfile
 gemspec
 
 group :development do
-  gem "chef", git: "https://github.com/chef/chef" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.2") # until stable 12.14 is released (won't load new cheffish and such otherwise)
   gem 'guard'
   gem 'guard-rspec'
   gem 'rb-readline'


### PR DESCRIPTION
Chef 12.14 has been released so we no longer need to do this

Signed-off-by: Tim Smith<tsmith@chef.io>