### PR TITLE
allow cheffish-5.0

### DIFF
--- a/chef-provisioning-fog.gemspec
+++ b/chef-provisioning-fog.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/chef/chef-provisioning-fog'
 
   s.add_dependency 'chef-provisioning', '>= 1.0', '< 3.0'
-  s.add_dependency 'cheffish', '~> 4.0'
+  s.add_dependency 'cheffish', '>= 4.0', '< 6.0'
   s.add_dependency 'fog', '>= 1.37.0'
   s.add_dependency 'google-api-client', "~> 0.8.0"
   s.add_dependency 'fog-softlayer' , '~> 1.1'


### PR DESCRIPTION
this is blocking all of chef-dk being able to get onto cheffish-5.0

no need AFAIK to drop cheffish-4.0 support
