### PR TITLE
Fix empty SSH user in ssh gateway parameter

### DIFF
--- a/.idea/chef-provisioning-fog.iml
+++ b/.idea/chef-provisioning-fog.iml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+    <local />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.12.5, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="chef (v12.13.37, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="chef-provisioning (v1.9.1, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="fog (v1.38.0, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="fog-softlayer (v1.1.3, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="google-api-client (v0.8.6, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="guard (v2.14.0, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v11.2.2, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rb-readline (v0.5.3, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="retryable (v2.0.4, ruby-2.1.8-p440) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.5.0, ruby-2.1.8-p440) [gem]" level="application" />
+  </component>
+</module>

--- a/lib/chef/provisioning/fog_driver/driver.rb
+++ b/lib/chef/provisioning/fog_driver/driver.rb
@@ -703,7 +703,11 @@ module FogDriver
 
       #Enable pty by default
       options[:ssh_pty_enable] = true
-      options[:ssh_gateway] = machine_spec.reference['ssh_gateway'] if machine_spec.reference.has_key?('ssh_gateway')
+      if machine_options[:ssh_gateway]
+        options[:ssh_gateway] = machine_options[:ssh_gateway]
+      elsif machine_spec.reference.has_key?('ssh_gateway')
+        options[:ssh_gateway] = machine_spec.reference['ssh_gateway']
+      end
 
       Transport::SSH.new(remote_host, username, ssh_options, options, config)
     end


### PR DESCRIPTION
Dear Chef guys,

When I am setting ssh_gateway for machine resource using chef-provisioning-fog
`[:machine_options][:ssh_gateway] = 'USER@HOST'`

Afterwards chef-provisioning's method 'gateway' receives ssh_gateway without USER right here:
`gw_user, gw_host = options[:ssh_gateway].split('@')`

Could you, please, consider this PR?

Thank you in advance!